### PR TITLE
[23주차 1] 2025 반디 플래너 제작 제안서

### DIFF
--- a/hong/bandi-planner/2025 플래너 제작 제안서.md
+++ b/hong/bandi-planner/2025 플래너 제작 제안서.md
@@ -1,0 +1,172 @@
+# 2025 플래너 제작 기획서
+
+원본: https://www.notion.so/depromeet/2025-Planner-d8dc98a36af943f2bde13de210e0a87f?pvs=4
+
+### Brainstorming
+    
+Milestones:
+- 종이 플래너(객체) 제작 (8 ~ 9월, 10월 배포)
+- 종이 플래너 피드백 반영하여 반디플래너 MVP(유기체) 개발 (10 ~ 12월)
+    - core
+    - home
+    - lifemap (= bandiboodi)
+    - effort (= tracker)
+    - money (= fire | retirement | assets)
+    - wedding
+    - funeral
+    - pay
+    - gifts
+    - organizer (반디월드 = 동시 계획 세우기)
+    - …
+    
+TODO:
+- 7월: 플래너 조사, 기획서 작성 및 공유, 피드백 반영
+- 8월: 디자인 개발 (8/15)
+- 9월: 생산 계획 및 진행, 텀블벅 등 판매 방식 준비 (9/16~18)
+- 10월: 운영 (10/3, 10/9), 반디플래너 개발 진행
+- 11,12월: 반디플래너 개발 완료 (12/25, 1/1)
+
+잠재 이슈:
+- 디프만 이슈 (팀원들이 9월 말까지 바쁨)
+- 졸업 이슈 (대학생 참여 힘듦)
+- 이직 이슈 (이직 준비 대상자 참여 힘듦)
+
+---
+
+# 종이 플래너 제작(8 ~ 9월)
+
+## 시장 조사 (7/13)
+
+### 참고 자료:
+
+- https://m.blog.naver.com/jihyero_/222943047882?isInf=true
+- https://blog.naver.com/m_naru/222976569426
+- https://blog.naver.com/naver_diary/223278862012
+- https://blog.naver.com/PostView.naver?blogId=rushmush&logNo=223326142255&categoryNo=35&parentCategoryNo=-1&viewDate=&currentPage=&postListTopCurrentPage=&isAfterWrite=true
+- https://tumblbug.com/procend2?ref=검색/키워드
+- https://tumblbug.com/notion2024?ref=검색/키워드
+
+## 기획
+
+### Objectives:
+
+- 목표를 설정하고, 목표를 달성하기 위한 노력을 기록한다.
+- 단기보다는 1년간 꾸준히 할 수 있는 목표를 달성하기 위한 솔루션을 제공한다.
+- 기존의 월별 플래너의 단점을 보완하여 매일의 노력과 시간을 기록한다.
+- 연말이되면 노력에 대한 결과를 확인할 수 있으며, 그에 따라 조금더 명확하게 인생 계획을 세울 수 있다.
+- 플래너를 다 작성하면 “내가 2025년을 이렇게 열심히 보냈다”리고 생각할 수 있게 기록물 형식의 프레너를 제공한다.
+- 1월 1일까지 기다려서 진행하는 게 아닌 플래너를 받음과 동시에 쉽게 시작할 수 있는 컨텐츠를 제공한다.
+
+### Contents:
+
+- 플래너는 장기(yearly) > 중기(monthly) > 단기(daily) 순으로 컨텐츠를 제공하며, 최종장(life)에는 인생 지도 페이지를 제공한다.
+
+**Yearly: 목표 설정과 달성도 확인**
+
+- **만다라트 만들기**
+    - 목표를 구체화하고 실제로 이루는 데 효과가 있음.
+    - `최종 목표 > 서브 목표 > 습관` 으로 구성.
+        <img width="592" alt="Screenshot 2024-07-13 at 4 52 45 PM" src="https://github.com/user-attachments/assets/8046cd6e-a0f4-48b6-9e53-ef9cf75447dc">
+
+    - 우측에 각 세부 별로 구체적인 설명을 적을 수 있는 필드 제공
+        - 예시: 디테일 버전
+          
+          <img width="352" alt="Screenshot 2024-07-13 at 6 39 16 PM" src="https://github.com/user-attachments/assets/dd3a7b35-78cb-4685-9042-601b585d6479">
+
+        - 예시: 심플 버전
+          
+          <img width="240" alt="Screenshot 2024-07-13 at 6 27 23 PM" src="https://github.com/user-attachments/assets/4433c89d-6aff-45f8-a776-9490ea0dcb82">
+
+- **milestones 기록하기**
+    - 연간 목표를 달성하기 위해 노력하면서 얻은 milestone을 기록 (위의 서브 목표 정도, 뭐든 자유롭게 더 추가 가능하도록)
+    - 예시
+    
+      <img width="670" alt="Screenshot 2024-07-13 at 6 25 27 PM" src="https://github.com/user-attachments/assets/ce8312a3-be0b-4477-b37a-161757f14139">
+
+**Monthly: 노력에 대한 중간 평가 기록 및 확인 (성과 보상)**
+
+- **성과 그래프 (성과 측정하기)**
+    - 매월 측정할 수 있는 기준을 설정해서 노력에 따라 우상향하는지 확인
+        - 예: 몸무게, 자산, 운동 능력, 투자 시간, 성적, 팔로워 수, 포스팅 수 등
+        - 예시
+          
+          <img width="184" alt="Screenshot 2024-07-13 at 5 23 09 PM" src="https://github.com/user-attachments/assets/9fc8d6cd-59a3-4e8f-8f87-7cfcaaa21cfd">
+  
+
+- **월별 회고 필드**
+    - 월별로 회고를 할 수 있는 필드 제공 (성과 그래프 우측에 성과에 대한 회고 작성 필드 제공. 1월 ~ 12월)
+    - 예시
+      
+      <img width="419" alt="Screenshot 2024-07-13 at 6 40 29 PM" src="https://github.com/user-attachments/assets/85168a39-2640-4728-ace4-8e590e7d31fd">
+        
+
+**Daliy: 매일의 노력 기록 및 습관 생성**
+
+조건: 연간 매일 노력 진행상황을 한눈에 볼 수 있어야 함.
+
+- **만다라트의 습관 만들기**
+    - 습관을 만들고 싶은 목표를 위에 적고 아래 연간 **“잔디 채우기”** 색칠하기
+
+- **잔디 채우기**
+    - 매일 투자한 시간 기입, 또는 강도에 따라 색을 다르게 칠하는 방식
+    - 가로는 월/주를 뜻함. 세로는 요일을 뜻함. (일 ~ 월)
+        - 예시 1: 깃헙 잔디
+          
+            <img width="202" alt="Screenshot 2024-07-13 at 4 49 29 PM" src="https://github.com/user-attachments/assets/cbd0804a-10f6-4878-b655-baec205e83f9">
+ 
+            <img width="199" alt="Untitled11" src="https://github.com/user-attachments/assets/0e23b582-cc22-46aa-894d-064817a0d43e">
+
+            
+        - 예시 2: 365 캘린더
+          
+            <img width="644" alt="Untitled12" src="https://github.com/user-attachments/assets/399b40e8-a630-48cb-a538-1e6c9f0d233d">
+
+- **TODO 기록하기**
+    - 쓰고, 지우고, 해결하지 못한 것을 다음 날에 다시 기록하고 하는 과정이 불필요하게 들어가는 문제를 해결.
+    - 연간 지속적으로 생성되는 TODO를 연속적으로 입력할 수 있는 컨텐츠 제공.
+        - 폐이지가 여러 장 존재. 연간 생성되는 TODO를 아래 계속 입력해서 중복 제거 효과와 공간 효율화, 해결한 작업을 쌓아가는 성취감을 동시에 얻을 수 있음.
+        - 예시: 중요도 → 기입 날짜로 변경, 완료 → 완료한 날짜로 입력
+     
+            ![Untitled13](https://github.com/user-attachments/assets/8e8dd478-002c-4bec-87ed-adf1b5cd745a)
+
+
+- **목표 n번 쓰기**
+    - [반복적으로 목표를 적으면서 습관을 바꾸고 목표 결국 달성하는 목적](https://tumblbug.com/procend2?ref=%EA%B2%80%EC%83%89%2F%ED%82%A4%EC%9B%8C%EB%93%9C).
+    - 매일 사용할 수 있는 간단한 로그 필드 제공
+        - todo 또는 이룬 내용을 입력할 수 있도록 함.
+        - 일자는 직접 입력해서 로그를 남기고 싶은 것만 할 수 있도록 함.
+
+**Life Map: 1년동안 고민한 결과를 통해 인생 지도 완성**
+
+- **인생 지도 만들기**
+    - 1년간 지속적으로 업데이트(지속적인 회고를 통해 인생 지도를 완성시켜 갈 수 있도록)
+    - 매일의 기록과 월별 성과 평가, 연간 목표 달성도 확인을 통해 장기 목표 수립.
+    - 예시
+      
+        ![별이되고_싶은_반디부디의_인생지도](https://github.com/user-attachments/assets/f0af9e50-9cdd-4a6d-9b78-692456d81c94)
+        
+    - 각 목표와 언제까지 달성하고 싶은지 시간 순으로 작성
+    - 디자인은 종이 플래너에 적합하고 개발 가능성을 고려하지 않고 자유로운 방식으로 변경
+
+**별첨: 플래너 컨탠츠와 별개인 아이디어 모음**
+
+- 플래너 스티커 제작?
+- 목표 관련된 [좋은 생각 카드 제작](https://www.coupang.com/vp/products/1548825688?itemId=2650777017&vendorItemId=70641486949&isAddedCart=)도 재밌을 듯
+- 플래너에 사용할 컬러링 팬 제공 (예: 연한 녹색 부터 진한 녹색까지)
+- 구매자에게 PDF 파일을 제공하는 방식도 좋을 듯 (패드에서 사용하는 걸 선호할 수도 있으니) ← 그럼 디자인 사이즈는 14~15인치 디스플레이 기준으로?
+- 예시
+  
+    <img width="608" alt="Screenshot 2024-07-13 at 7 30 23 PM" src="https://github.com/user-attachments/assets/def49522-e9bc-4002-a125-021247bcfaf9">
+    출처: [https://tumblbug.com/seizethetime?ref=검색%2F키워드](https://tumblbug.com/seizethetime?ref=%EA%B2%80%EC%83%89%2F%ED%82%A4%EC%9B%8C%EB%93%9C)
+    
+- [노션으로 만들어서 수익화하는 것도 좋을 듯](https://tumblbug.com/notion2024?ref=%EA%B2%80%EC%83%89%2F%ED%82%A4%EC%9B%8C%EB%93%9C)
+    
+    
+
+## 피드백 반영 (7/20~21)
+
+## 최종 계획 검토 및 확정 (7/27~28)
+
+## 종이 플래너 디자인 작업 (8월)
+
+## 종이 플래너 생산, 홍보, 판매 (9월)


### PR DESCRIPTION
<!--
1. 글 주제
2. 글과 관련된 키워드들
-->

## 📒 글 제목
- 반디부디의 미래를 생각하며 2025년 계획을 세웠습니다.
- 10월까지 제작할 "2025 플래너" 관련 제안서를 작성했습니다. 
- 이 자료는 1차 제안서이며 조정한씨의 피드백을 반영된 최종 제안서를 제작할 계획입니다.

## 📜 관련 키워드
2025 반디 플래너 만들기 프로젝트

---
